### PR TITLE
improve portability

### DIFF
--- a/r2elk.py
+++ b/r2elk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
     R2ELK is a Python binary parsing utility that leverages the Radare2 Python
     API. Metadata extracted from the binaries is then presented to the end user


### PR DESCRIPTION
osx doesn't have `python3` in `/usr/bin/`